### PR TITLE
Exclude docs + tests files from wheel contents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,10 +127,8 @@ whois-bridge-service = "jaraco.net.whois_svc:Service.handle_command_line"
 # wget = jaraco.net.http:wget
 
 [tool.setuptools.packages.find]
-exclude = [
-	"sandbox",
-	"pinger",
-	"ubuntu",
+include = [
+	"jaraco*",
 ]
 
 


### PR DESCRIPTION
uv recently adding a warning if multiple dependencies install similarly named packages. With that I noticed that `jaraco.net` included the `tests` and `docs` directories in its wheel. I believe they should only be included in the sdist.

`dist-info/RECORD` diff
```diff
-docs/conf.py,sha256=xjAhaC-aUfuMYlYRgFduDcsBR3o0xTb0o6oP8k1wOFE,1723
-docs/history.rst,sha256=VMlH5ooZwqyknSu6f6gB32Q_T9DDBc0Y3tFCDYar7tI,78
-docs/index.rst,sha256=kY43GqdDeozji-8JRuh_DRSV0zx7FIYoEdzWaC5XkFc,2384
 jaraco/net/__init__.py,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 jaraco/net/dns.py,sha256=17VG8VOIISkfEqU4jvQzTt-an1debw0pdJJYe71OMaA,5098
 jaraco/net/dnsbl.py,sha256=gDsKXQ1BFHGKfobjxClL0mNntNlHHJZvrtsQlVzciOg,1844
 jaraco/net/icmp.py,sha256=9NS-b-SQgmPcdpuOlwBb80qAJ3CeA0bDjPFg2zisMpc,1679
 jaraco/net/importer.py,sha256=66eOYqIlaJhtunGA5lj7uJKD1gTdufN4jDZP0h32nFk,1907
 jaraco/net/inet.py,sha256=2WD2bhoVt4_-nlsTBlBopjulHyA1hpmdL56htxo_mgU,3419
 jaraco/net/ntp.py,sha256=hYycd9CpPR_NWHEQigxZn4jwtb2HxoFcae_DUadZcyk,1984
 jaraco/net/ping-isp.py,sha256=jTIHsfbFuaLd91saN_F7h3QWGf5Ohme6l91S61G77qM,987
 jaraco/net/rss.py,sha256=6zdRFkkyrQyXexAUxbIItoXTtUzTMwI12nJnP7KLttU,3960
 jaraco/net/scanner.py,sha256=m8BqA71P0j4QFwswJQZlM6hijkhJoLHyTre3T44CgE8,4273
 jaraco/net/site.py,sha256=ZhJHCBFHBq2QRR4QqRYb1ThVc-54lLGN3qM9GCpdMfs,566
 jaraco/net/stats.py,sha256=NLCqVkyRxVID_MvdF1uchoB9CSb_yinKTR_zjITsM2s,4732
 jaraco/net/tail.py,sha256=nX_blU4DeDaXahIjqy_nYFpeaynFWJXwPJAB7qik_M0,1823
 jaraco/net/tcp.py,sha256=Y1Ar1lUSB91FCUkwO9uTGSinHsEON0oPWRMP1yHpTzo,1030
 jaraco/net/udp.py,sha256=RyStWVCxGp1ObKAMY_LWhiEAwVzcR3aJF_kVKLKINR0,1793
 jaraco/net/wake.py,sha256=HfiVjl8ZQ_ov46bYgxhRcrrR1uJcQ4uCmcB00izWIgQ,496
 jaraco/net/devices/__init__.py,sha256=u8QzR9HLlc0z7ve-_PchiLCzMV7sQX8g0IC1iuwRe9o,238
 jaraco/net/devices/base.py,sha256=imtjZaynDXshU6TKp9tVxjcyUKgUcZh5woQvn15XYgo,1725
 jaraco/net/devices/darwin.py,sha256=3SHu99XyzEA0NV-s1VpyuKmJhT5VrnMjPCzcyYM5yiI,598
 jaraco/net/devices/linux.py,sha256=l97JXgfP3VsFjxV2fiGz5UzsGMQalC3Mje4znWT9vHA,2905
 jaraco/net/devices/win32.py,sha256=XGtJUAlFHzaiWwlamuSYCbPYfIOinfhp3bkxbS9xmx4,4682
 jaraco/net/http/__init__.py,sha256=f6wLpp5xvPwD2ACKzbWqiYyEWgCTp2jP7SQjSBmdDPc,5270
 jaraco/net/http/caching.py,sha256=xYwp8UxcALiQo5USCEGOV97VEHTi59QsYeppF74OohY,10584
 jaraco/net/http/content.py,sha256=_e9lz1cimCkONAYtFcGMFjBxiB0r3SvEd-CdoYDartw,510
 jaraco/net/http/cookies.py,sha256=srVU7jRmAohzV1yvxu0fHQTdturC6Oo1PXKEspjkfsk,2709
 jaraco/net/http/htmldir.py,sha256=XVq4RJdp_y57y-wOe592IS-n420UEaGuZ5Ev1W4nL-g,1628
 jaraco/net/http/servers.py,sha256=OY7lOCcdRtgqOm9IP2n39xcouzHwihHKziuEqW8nqbs,4864
 jaraco/net/http/static.py,sha256=lERxdqKzflTbYKWBnqCXSAVS58zyQtcNEIdZdn53hic,727
 jaraco/net/http/staticdirindex.py,sha256=s8kUIKZ_OU4e-2-3aNZnz5aSpEs4Gg8gdvWWP2P1xnQ,4465
 jaraco/net/pinger/pinger.conf,sha256=n5au4nPS_jFkQqU_E9p4aPayTemE6XJ1egREIVDKeCY,315
 jaraco_net-10.2.4.dev22+g31ed85b.dist-info/licenses/LICENSE,sha256=WlfLTbheKi3YjCkGKJCK3VfjRRRJ4KmnH9-zh3b9dZ0,1076
 jaraco_net-10.2.4.dev22+g31ed85b.dist-info/METADATA,sha256=RbhlJztKBvgz_Yn3l2n9I0IgZNcIKAhN9HLg8lA26n0,4114
 jaraco_net-10.2.4.dev22+g31ed85b.dist-info/WHEEL,sha256=_zCd3N1l69ArxyTb8rzEoP9TpbYXkqRFSNOD5OuxnTs,91
 jaraco_net-10.2.4.dev22+g31ed85b.dist-info/entry_points.txt,sha256=9cHRLHJsvGQgnx-TNsWsfLTG8Pj3pFQ0WqeshnBjhrY,1080
-jaraco_net-10.2.4.dev22+g31ed85b.dist-info/top_level.txt,sha256=7zTWEXwVUwCo8B30hvT4tASDnY27q9cI701MlLSz1A0,18
+jaraco_net-10.2.4.dev22+g31ed85b.dist-info/top_level.txt,sha256=0JnN3LfXH4LIRfXL-QFOGCJzQWZO3ELx4R1d_louoQM,7
 jaraco_net-10.2.4.dev22+g31ed85b.dist-info/RECORD,,
-tests/nic.bo.html,sha256=wxo3bd_-uzVDzN9PklbLdb3oGly_1xV8IrpxaaYbGoA,39289
-tests/test_cookies.py,sha256=xi7Ol9x5SchpmFBJbuCMvn-NZqaQANFo-ADC7xXXtNI,720
-tests/test_importer.py,sha256=-CHaRnB_me-iTgR9oD5S4XYuNI9HXDAgbrNYQTVnXXc,877
-tests/http/test_caching.py,sha256=g4ht4WSBznFgVlfYPd9FCrylwHpsWiag8Cj359t6R5U,960
```

Ref: https://github.com/home-assistant/core/pull/150630